### PR TITLE
OZ-448: Upgrade SENAITE to 2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,76 @@
 # Use an official Python runtime as a parent image
-FROM python:2.7-stretch
+FROM python:2.7-slim-buster
 
 # Set one or more individual labels
 LABEL maintainer="Mekom Solutions"
 LABEL email="info@mekomsolutions.com"
-LABEL senaite.core.version="2.0.0rc2"
+LABEL senaite.core.version="v2.3.0"
 
 # Set environment variables
 ENV PLONE_MAJOR=5.2 \
-    PLONE_VERSION=5.2.2 \
-    PLONE_MD5=a603eddfd3abb0528f0861472ebac934 \
-    PLONE_UNIFIED_INSTALLER=Plone-5.2.2-UnifiedInstaller \
-    SENAITE_HOME=/home/senaite \
-    SENAITE_USER=senaite \
-    SENAITE_INSTANCE_HOME=/home/senaite/senaitelims \
-    SENAITE_DATA=/data \
-    SENAITE_FILESTORAGE=/data/filestorage \
-    SENAITE_BLOBSTORAGE=/data/blobstorage
+  PLONE_VERSION=5.2.9 \
+  PLONE_MD5=fe4bac71688e9704a21f7877680f1374 \
+  PLONE_UNIFIED_INSTALLER=Plone-5.2.9-UnifiedInstaller-1.0 \
+  SENAITE_HOME=/home/senaite \
+  SENAITE_USER=senaite \
+  SENAITE_INSTANCE_HOME=/home/senaite/senaitelims \
+  SENAITE_DATA=/data \
+  SENAITE_FILESTORAGE=/data/filestorage \
+  SENAITE_BLOBSTORAGE=/data/blobstorage
 
 # Create the senaite user
 RUN useradd --system -m -d $SENAITE_HOME -U -u 500 $SENAITE_USER
 
-# Create direcotries
+# Create directories
 RUN mkdir -p $SENAITE_INSTANCE_HOME $SENAITE_FILESTORAGE $SENAITE_BLOBSTORAGE
 
-# Copy the package config
-COPY resources/packages.txt /
+# Copy Buildout
+COPY resources/requirements.txt resources/versions.cfg resources/buildout.cfg resources/develop.cfg $SENAITE_INSTANCE_HOME/
 
-# Install package dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /packages.txt  | tr "\n" " ")
+#RUN chown -R senaite:senaite $SENAITE_INSTANCE_HOME $SENAITE_FILESTORAGE $SENAITE_BLOBSTORAGE
 
-# Fetch unified installer
-RUN wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_UNIFIED_INSTALLER.tgz \
-    && echo "$PLONE_MD5 Plone.tgz" | md5sum -c - \
-    && tar -xzf Plone.tgz \
-    && cp -rv /$PLONE_UNIFIED_INSTALLER/base_skeleton/* $SENAITE_INSTANCE_HOME \
-    && cp -v /$PLONE_UNIFIED_INSTALLER/buildout_templates/buildout.cfg $SENAITE_INSTANCE_HOME/buildout-base.cfg \
-    && cd $SENAITE_HOME \
-    && rm -rf /$PLONE_UNIFIED_INSTALLER /Plone.tgz
+# Copy the build dependencies and startup scripts
+COPY resources/build_deps.txt resources/run_deps.txt resources/docker-initialize.py resources/docker-entrypoint.sh /
+
+# Note: we concatenate all commands to avoid multiple layer generation and reduce the image size
+RUN apt-get update \
+  # Install system pakages
+  && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /build_deps.txt | tr "\n" " ") \
+  && apt-get install -y --no-install-recommends $(grep -vE "^\s*#" /run_deps.txt | tr "\n" " ") \
+  # Fetch unified installer
+  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_UNIFIED_INSTALLER.tgz \
+  && echo "$PLONE_MD5 Plone.tgz" | md5sum -c - \
+  && tar -xzf /Plone.tgz \
+  && cp -rv $PLONE_UNIFIED_INSTALLER/base_skeleton/* $SENAITE_INSTANCE_HOME \
+  && cp -v $PLONE_UNIFIED_INSTALLER/buildout_templates/buildout.cfg $SENAITE_INSTANCE_HOME/buildout-base.cfg \
+  && rm -rf $PLONE_UNIFIED_INSTALLER Plone.tgz \
+  && git clone  https://github.com/mekomsolutions/plone.initializer.git $SENAITE_INSTANCE_HOME/src/plone.initializer \
+  && cd $SENAITE_INSTANCE_HOME/src/plone.initializer && git checkout main \
+  && git clone  https://github.com/mekomsolutions/senaite.indexer.git $SENAITE_INSTANCE_HOME/src/senaite.indexer \
+  && cd $SENAITE_INSTANCE_HOME/src/senaite.indexer && git checkout main \
+  && git clone  https://github.com/mekomsolutions/senaite.monkeypatches.git $SENAITE_INSTANCE_HOME/src/senaite.monkeypatches\ 
+  && cd $SENAITE_INSTANCE_HOME/src/senaite.monkeypatches && git checkout main
+# Buildout
+
+RUN cd $SENAITE_INSTANCE_HOME \
+  && pip install -r requirements.txt \
+  && buildout -c develop.cfg \
+  && ln -s $SENAITE_FILESTORAGE/ var/filestorage \
+  && ln -s $SENAITE_BLOBSTORAGE/ var/blobstorage \
+  && chown -R senaite:senaite $SENAITE_HOME $SENAITE_DATA \
+  # Cleanup
+  && apt-get purge -y --auto-remove $(grep -vE "^\s*#" /build_deps.txt  | tr "\n" " ") \
+  && rm -rf /$SENAITE_HOME/buildout-cache \
+  && rm -rf /var/lib/apt/lists/*
 
 # Change working directory
 WORKDIR $SENAITE_INSTANCE_HOME
 
-# Copy Buildout
-COPY resources/requirements.txt resources/versions.cfg resources/buildout.cfg resources/develop.cfg ./
-
-RUN chown -R senaite:senaite $SENAITE_INSTANCE_HOME $SENAITE_FILESTORAGE $SENAITE_BLOBSTORAGE
-
-RUN git clone  https://github.com/mekomsolutions/plone.initializer.git $SENAITE_INSTANCE_HOME/src/plone.initializer && cd $SENAITE_INSTANCE_HOME/src/plone.initializer && git checkout main
-RUN git clone  https://github.com/mekomsolutions/senaite.indexer.git $SENAITE_INSTANCE_HOME/src/senaite.indexer && cd $SENAITE_INSTANCE_HOME/src/senaite.indexer && git checkout main
-RUN git clone  https://github.com/mekomsolutions/senaite.monkeypatches.git $SENAITE_INSTANCE_HOME/src/senaite.monkeypatches && cd $SENAITE_INSTANCE_HOME/src/senaite.monkeypatches && git checkout main
-
-# Buildout
-RUN pip install -r requirements.txt \
-    && buildout -c develop.cfg\
-    && ln -s $SENAITE_FILESTORAGE/ var/filestorage \
-    && ln -s $SENAITE_BLOBSTORAGE/ var/blobstorage \
-    && chown -R senaite:senaite $SENAITE_HOME $SENAITE_DATA
-
 # Mount external volume
 VOLUME /data
 
-# Copy startup scripts
-COPY resources/docker-initialize.py resources/docker-entrypoint.sh /
-
 # Expose instance port
 EXPOSE 8080
-
-# Add instance healthcheck
-HEALTHCHECK --interval=1m --timeout=5s --start-period=1m \
-  CMD nc -z -w5 127.0.0.1 8080 || exit 1
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["start"]

--- a/resources/build_deps.txt
+++ b/resources/build_deps.txt
@@ -1,0 +1,14 @@
+dpkg-dev
+gcc
+libbz2-dev
+libc6-dev
+libffi-dev
+libjpeg62-turbo-dev
+libopenjp2-7-dev
+libpcre3-dev
+libtiff5-dev
+libxml2-dev
+libxslt1-dev
+wget
+zlib1g-dev
+git

--- a/resources/buildout.cfg
+++ b/resources/buildout.cfg
@@ -1,187 +1,44 @@
-############################################
-#
-# Buildout Configuration File for Plone
-# -------------------------------------
-#
-# ALWAYS back up all Plone/Zope data and components
-# before changing configuration.
-#
-# Running "bin/buildout" will update your installation,
-# installing missing components as necessary.
-#
-# This will update the add-on products you've added in the eggs= lines.
-# This will not, however, upgrade Plone itself (or anything else you've
-# pinned with a version specification). To upgrade Plone itself, see the
-# comments in "Plone Component Versions".
-#
-# Tutorial instructions for using zc.buildout for
-# configuration management are available at:
-# https://docs.plone.org/manage/installing/installing_addons.html
-# Full details at http://pypi.python.org/pypi/zc.buildout
-#
-############################################
-
-
 [buildout]
-
-# buildout.sanitycheck makes sure you're not running buildout
-# as root.
-extensions =
-    buildout.environ
-
-############################################
-# Plone Component Versions
-# ------------------------
-# This version of the Unified Installer has the components of Plone 5
-# preloaded so that it can install without an Internet connection.
-# If you want to update, uncomment the "http://..." line below,
-# edit it to point to the current version URL, comment out the
-# "versions.cfg" line and run "bin/buildout" while attached to the
-# Internet. Generally, you only want to do that as part of a planned migration.
-# Note that if you are updating components, you should also check the versions
-# section at the end of this file, since recipes or components other than
-# those of Zope and Plone may need updating at the same time.
-#
+index = https://pypi.python.org/simple/
 extends =
   buildout-base.cfg
-  versions.cfg
-#    https://dist.plone.org/release/5.2.2/versions.cfg
+extensions = mr.developer
 
-# If you change your Plone version, you'll also need to update
-# the repository link below.
-find-links +=
-    https://dist.plone.org/release/5.2.3
-
-# This user will own the non-data parts of src/senaite.corethe installation, and should be used to
-# run buildout.
-effective-user = senaite
-buildout-user = senaite
-# A flag to tell the Unified Installer whether or not to document sudo use.
-need-sudo = no
-
-
-############################################
-# Eggs
-# ----
-# Add an indented line to the eggs section for any Python
-# eggs or packages you wish to include in your Plone instance.
-#
-# Note that versions may be specified here or in the [versions]
-# section below. You should always specify versions that you know
-# are compatible with the Plone release and at an acceptable
-# development level.
-#
-# If you update to a later version of Plone, remove the hotfix.
-#
-eggs =
-    Plone
-    Pillow
-    Products.PloneHotfix20200121
-    senaite.lims
-    collective.recipe.plonesite
-    plone.initializer
-    senaite.indexer
-    senaite.monkeypatches
-
-
-
-############################################
-# ZCML Slugs
-# ----------
-# Some eggs need ZCML slugs to tell Zope to
-# use them. This is increasingly rare.
-zcml =
-#    plone.reload
-
-
-
-############################################
-# Development Eggs
-# ----------------
-# You can use paster to create "development eggs" to
-# develop new products/themes. Put these in the src/
-# directory.
-# You will also need to add the egg names in the
-# eggs section above, and may also need to add them
-# to the zcml section.
-#
-# Provide the *paths* to the eggs you are developing here:
-develop =
-   src/plone.initializer
-   src/senaite.indexer
-   src/senaite.monkeypatches
-
-
-############################################
-# var Directory
-# -------------
-# Sets the target directory for the "var" components of the install such as
-# database and log files.
-#
 var-dir=/data
-
-
-############################################
-# Backup Directory
-# ----------------
-# Sets the target directory for the bin/backup and bin/snapshotbackup
-# commands. Default is inside this project's var directory, but ideally
-# this should be on a separate volume or backup server.
-#
-backups-dir=/data
-
-
-############################################
-# Initial User
-# ------------
-# This is the user id and password that will be used to create the initial
-# user id that will allow you to log in and create a Plone site. This only
-# sets the initial password; it will not allow you to change an already
-# existing password. If you change the admin password via the web interface,
-# the one below will no longer be valid.
-# If you find yourself locked out of your Zope/Python installation, you may
-# add an emergency user via "bin/plonectl adduser".
 user=admin:admin
 
+effective-user = senaite
+buildout-user = senaite
 
-############################################
-# Debug Options
-# -------------
-# Start Zope/Plone instances in "fg" mode to turn on debug mode;
-# this will dramatically slow Plone.
-#
-# Add-on developers should turn deprecation warnings on
-deprecation-warnings = off
-# change verbose-security to "on" for useful security errors while developing
-verbose-security = off
+eggs-directory=eggs
+download-cache=../buildout-cache/downloads
 
+parts +=
+  zeo
+  plonesite
+  console_scripts
 
-############################################
-# Parts Specification
-#--------------------
-# Specifies the components that should be included in the buildout.
-# Most are defined in the base.cfg extension; you may add your
-# own if you need them at the end of this file.
-parts =
-    instance
-    repozo
-    backup
-    zopepy
-    unifiedinstaller
-    plonesite
-    print
+eggs +=
+    senaite.lims
 
-############################################
-# Major Parts
-# ----------------------
-# These common parts make use of sane base settings from
-# base.cfg. To customize a part, just add whatever options
-# you need. Read base.cfg for common settings.
+[client1]
+recipe =
+
+[zeo]
+<= zeoserver_base
+recipe = plone.recipe.zeoserver
+zeo-address = 8080
 
 [instance]
-<= instance_base
-recipe = plone.recipe.zope2instance
-http-address = 8080
+# taken from https://github.com/plone/plone.docker/blob/master/5.2/5.2.5/python2/buildout.cfg
+event-log-handler = StreamHandler
+event-log-args = (sys.stderr,)
+access-log-handler = StreamHandler
+access-log-args = (sys.stdout,)
+
+[console_scripts]
+recipe = zc.recipe.egg:scripts
+eggs = senaite.core
 
 [plonesite]
 recipe = collective.recipe.plonesite
@@ -190,40 +47,16 @@ site-id = senaite
 profiles-initial = Products.CMFPlone:dependencies
 profiles =
     senaite.lims:default
-    plone.initializer:default
-    senaite.indexer:default
-    senaite.monkeypatches:default
 upgrade-portal = False
 upgrade-all-profiles = False
 enabled = False
 
-[print]
-recipe = mr.scripty
-install =
-    print("Found in environ: PATH=${__environ__:PATH}")
-
-############################################
-# Versions Specification
-# ----------------------
-# Version information supplied here will "pin" Python packages to a particular
-# version number, even when you use the "newest" flag running buildout.
-# Specifying versions for all packages is a good idea and can prevent
-# accidental changes when you add new packages to your buildout.
-# Note that versions specified here will override those specified earlier
-# in the configuration, including those from the Plone and Zope version
-# config files.
-#
 [versions]
-
-buildout.sanitycheck = 1.0.2
-collective.recipe.backup = 4.1.0
-plone.recipe.unifiedinstaller = 5.2b1
-Products.PloneHotfix20200121 = 1.1
-setuptools=42.0.2
+setuptools = 42.0.2
+senaite.lims = 2.3.0
 zc.buildout=2.13.3
-senaite.core=2.1.0
-senaite.lims=2.1.0
-senaite.jsonapi=2.1.0
 Werkzeug = 1.0.0
 cryptography = 2.9.2
-# dm.xmlsec.binding = 2.0
+bobtemplates.plone=5.2.2
+isort=4.3.21
+regex = 2020.2.20

--- a/resources/requirements.txt
+++ b/resources/requirements.txt
@@ -1,4 +1,1 @@
-setuptools==42.0.2
-zc.buildout==2.13.3
-wheel
-pyphen==0.10.0
+-r https://dist.plone.org/release/5.2.14/requirements.txt

--- a/resources/run_deps.txt
+++ b/resources/run_deps.txt
@@ -1,0 +1,14 @@
+git
+gosu
+libcairo2
+libgdk-pixbuf2.0-0
+libjpeg62
+libopenjp2-7
+libpango-1.0-0
+libpangocairo-1.0-0
+libtiff5
+libxml2
+libxslt1.1
+lynx
+rsync
+vim


### PR DESCRIPTION
This PR upgrades the version of SENAITE to 2.3.0. We also had to pin a few more dependencies to be able to build the image. Another thing to note is we are still not using the upstream SENAITE image as the base, as we have not gotten any response from the community about support for ARM. Find the released ticket [here](https://mekomsolutions.atlassian.net/browse/OZ-448) .